### PR TITLE
Add extra-flags for configure on compile

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 strongswan_version: "5.8.2"
 strongswan_config_file:  "{{strongswan_prefix}}/ipsec.conf"
 strongswan_secrets_file: "{{strongswan_prefix}}/ipsec.secrets"
+strongswan_configure_extra_args: "--enable-systemd --enable-swanctl"
 charon_filelog: "/var/log/charon.log"
 
 strongswan_config_setup:

--- a/tasks/install/Debian.yml
+++ b/tasks/install/Debian.yml
@@ -21,7 +21,9 @@
       remote_src: yes
 
   - name: run configure script
-    command: ./configure --prefix=/usr --sysconfdir=/etc
+    command: >
+      ./configure --prefix=/usr --sysconfdir=/etc
+      {{ strongswan_configure_extra_args }}
     args:
       chdir: '/tmp/strongswan-{{ strongswan_version }}'
     become: true


### PR DESCRIPTION
This flag is setted with default value that enables systemd support. This allow us to enable ipsec on start using legacy ipsec command